### PR TITLE
feat: 읽지 않은 알림 갯수 조회

### DIFF
--- a/src/main/java/com/example/wherewego/domain/courses/controller/NotificationController.java
+++ b/src/main/java/com/example/wherewego/domain/courses/controller/NotificationController.java
@@ -1,11 +1,14 @@
 package com.example.wherewego.domain.courses.controller;
 
 import org.springframework.http.HttpStatus;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.example.wherewego.domain.auth.security.CustomUserDetail;
 import com.example.wherewego.domain.courses.dto.request.NotificationRequestDto;
 import com.example.wherewego.domain.courses.dto.response.NotificationResponseDto;
 import com.example.wherewego.domain.courses.service.NotificationService;
@@ -38,6 +41,22 @@ public class NotificationController {
 
 		NotificationResponseDto responseDto = notificationService.createNotification(requestDto);
 		return ApiResponse.ok("알림이 성공적으로 생성되었습니다.", responseDto);
+	}
+
+	/**
+	 * 읽지 않은 알림 개수 조회
+	 * @param userDetail 인증된 사용자 정보
+	 * @return 읽지 않은 알림 개수(Long)
+	 */
+	@GetMapping("/api/notifications/unread-count")
+	public ApiResponse<Long> getUnreadNotificationCount(
+		@AuthenticationPrincipal CustomUserDetail userDetail
+	) {
+		Long userId = userDetail.getUser().getId();
+
+		long count = notificationService.getUnreadCount(userId);
+
+		return ApiResponse.ok("읽지 않은 알림 개수 조회 성공", count);
 	}
 
 }

--- a/src/main/java/com/example/wherewego/domain/courses/repository/NotificationRepository.java
+++ b/src/main/java/com/example/wherewego/domain/courses/repository/NotificationRepository.java
@@ -14,5 +14,5 @@ public interface NotificationRepository extends JpaRepository<Notification, Long
 	Page<Notification> findByReceiverIdOrderByCreatedAtDesc(Long receiverId, Pageable pageable);
 
 	// 읽지 않은 알림만 조회 (상단 알림뱃지 갯수)
-	// List<Notification> findByUserIdAndIsReadFalse(Long userId);
+	long countByReceiverIdAndIsReadFalse(Long receiverId);
 }

--- a/src/main/java/com/example/wherewego/domain/courses/service/NotificationService.java
+++ b/src/main/java/com/example/wherewego/domain/courses/service/NotificationService.java
@@ -140,6 +140,13 @@ public class NotificationService {
 	}
 
 	/**
+	 * 읽지 않은 알림 갯수 조회
+	 */
+	public long getUnreadCount(Long userId) {
+		return notificationRepository.countByReceiverIdAndIsReadFalse(userId);
+	}
+
+	/**
 	 * Notification 엔티티를 DTO로 변환합니다.
 	 */
 	private NotificationResponseDto toDto(Notification notification) {


### PR DESCRIPTION
## ✅ 작업 개요 (What)
알림기능
-읽지 않은 알림 갯수 조회

## 🛠️ 작업 내용 (How)
- [x] 읽지 않은 알림 갯수 조회 구현

## ⚠️ 설명
사용자(로그인 상태)로부터 토큰을 받아 인증 정보를 확인해서 UserId 추출
인증 객체에서 현재 로그인한 사용자의 userId를 가져오고
NotificationRepository에서 해당 userId의 isRead=false 인 알림만 모두 조회 (findByReceiverIdAndIsReadFalse).

*UserController가 아니라 NotificiationController에서 처리하고있는데
둘 중 어디다 써도 좀 애매해서 일단 NotificiationController로 넣었습니다~ (튜터님 추천)

## 📎 참고
상단 알림 뱃지라고 생각해주시면 됩니다
🔔2