### PR TITLE
Feat/caching : 좋아요/댓글/북마크 캐싱 적용

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,6 +42,7 @@ dependencies {
 
     // 외부 라이브러리
     implementation 'me.paulschwarz:spring-dotenv:4.0.0'
+    implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310' // LocalDateTime을 JSON으로 변환
 
     // 개발 도구
     compileOnly 'org.projectlombok:lombok'

--- a/src/main/java/com/example/wherewego/domain/courses/dto/response/CommentResponseDto.java
+++ b/src/main/java/com/example/wherewego/domain/courses/dto/response/CommentResponseDto.java
@@ -6,6 +6,7 @@ import com.example.wherewego.domain.courses.entity.Comment;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 /**
  * 댓글 응답 DTO
@@ -13,6 +14,7 @@ import lombok.Getter;
  */
 @Getter
 @AllArgsConstructor
+@NoArgsConstructor
 public class CommentResponseDto {
 
 	/**

--- a/src/main/java/com/example/wherewego/domain/courses/service/CourseBookmarkService.java
+++ b/src/main/java/com/example/wherewego/domain/courses/service/CourseBookmarkService.java
@@ -3,11 +3,14 @@ package com.example.wherewego.domain.courses.service;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -43,6 +46,7 @@ public class CourseBookmarkService {
 	private final UserService userService;
 	private final PlaceService placeService;
 	private final PlaceRepository placeRepository;
+	private final RedisTemplate<String, Object> redisTemplate;
 
 	/**
 	 * 코스에 북마크를 추가합니다.
@@ -67,6 +71,12 @@ public class CourseBookmarkService {
 		CourseBookmark savedBookmark = bookmarkRepository.save(bookmark);
 		// 북마크 수 +1
 		course.incrementBookmarkCount();
+		// 캐시 삭제
+		String pattern = "user-course-bookmark-list::userId:" + userId + ":*";
+		Set<String> keysToDelete = redisTemplate.keys(pattern);
+		if (keysToDelete != null && !keysToDelete.isEmpty()) {
+			redisTemplate.delete(keysToDelete);
+		}
 		// 반환
 		return new CourseBookmarkResponseDto(
 			savedBookmark.getId(),
@@ -94,6 +104,13 @@ public class CourseBookmarkService {
 		bookmarkRepository.delete(bookmark);
 		// 북마크 수 -1
 		course.decrementBookmarkCount();
+
+		// 캐시 삭제
+		String pattern = "user-course-bookmark-list::userId:" + userId + ":*";
+		Set<String> keysToDelete = redisTemplate.keys(pattern);
+		if (keysToDelete != null && !keysToDelete.isEmpty()) {
+			redisTemplate.delete(keysToDelete);
+		}
 	}
 
 	/**
@@ -107,6 +124,7 @@ public class CourseBookmarkService {
 	 * @return 북마크한 코스 목록과 페이지네이션 정보
 	 */
 	@Transactional(readOnly = true)
+	@Cacheable(value = "user-course-bookmark-list", key = "@cacheKeyUtil.generateCourseBookmarkListKey(#userId, #pageable.pageNumber, #pageable.pageSize)")
 	public PagedResponse<UserCourseBookmarkListDto> getUserCourseBookmarks(Long userId, Pageable pageable) {
 		// 1. 북마크된 CourseBookmark 엔티티 페이징 조회
 		Page<CourseBookmark> bookmarkPage = courseBookmarkRepository.findByUserId(userId, pageable);

--- a/src/main/java/com/example/wherewego/domain/courses/service/CourseLikeService.java
+++ b/src/main/java/com/example/wherewego/domain/courses/service/CourseLikeService.java
@@ -3,15 +3,16 @@ package com.example.wherewego.domain.courses.service;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 
-import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -52,6 +53,7 @@ public class CourseLikeService {
 	private final PlaceRepository placeRepository;
 	private final PlaceService placeService;
     private final NotificationService notificationService;
+	private final RedisTemplate<String, Object> redisTemplate;
 	
 	/**
 	 * 코스에 좋아요를 추가합니다.
@@ -65,8 +67,8 @@ public class CourseLikeService {
 	 *
 	 */
 	@Transactional
-	@CacheEvict(value = "course-like-list", key = "@cacheKeyUtil.generateCourseLikeListKey(#userId)")
 	public CourseLikeResponseDto createCourseLike(Long userId, Long courseId) {
+
 		int retries = 3;
 		while (true) {
 			try {
@@ -85,6 +87,14 @@ public class CourseLikeService {
 				course.incrementLikeCount();
 				courseRepository.save(course);
 				notificationService.triggerLikeNotification(user, course);
+
+				// 캐시 삭제
+				String pattern = "course-like-list::userId:" + userId + ":*";
+
+				Set<String> keysToDelete = redisTemplate.keys(pattern);
+				if (keysToDelete != null && !keysToDelete.isEmpty()) {
+					redisTemplate.delete(keysToDelete);
+				}
 
 				// 4) 결과 반환
 				return new CourseLikeResponseDto(
@@ -115,7 +125,6 @@ public class CourseLikeService {
 	 * @throws CustomException 좋아요가 존재하지 않는 경우
 	 */
 	@Transactional
-	@CacheEvict(value = "course-like-list", key = "@cacheKeyUtil.generateCourseLikeListKey(#userId)")
 	public void deleteCourseLike(Long userId, Long courseId) {
 		// 좋아요 존재 검사
 		CourseLike courseLike = likeRepository.findByUserIdAndCourseId(userId, courseId)
@@ -125,6 +134,14 @@ public class CourseLikeService {
 		// 코스 테이블의 좋아요 수(like_count) -1
 		Course course = courseService.getCourseById(courseId);
 		course.decrementLikeCount();
+
+		// 캐시 삭제
+		String pattern = "course-like-list::userId:" + userId + ":*";
+
+		Set<String> keysToDelete = redisTemplate.keys(pattern);
+		if (keysToDelete != null && !keysToDelete.isEmpty()) {
+			redisTemplate.delete(keysToDelete);
+		}
 	}
 
 	/**

--- a/src/main/java/com/example/wherewego/global/config/CacheConfig.java
+++ b/src/main/java/com/example/wherewego/global/config/CacheConfig.java
@@ -28,7 +28,7 @@ import org.springframework.data.redis.serializer.StringRedisSerializer;
  */
 @Configuration
 @EnableCaching
-//@Profile("!local") // local 프로필에서는 캐싱 비활성화
+@Profile("!local") // local 프로필에서는 캐싱 비활성화
 public class CacheConfig {
 
     /**
@@ -45,8 +45,8 @@ public class CacheConfig {
         objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS); // 날짜를 타임스탬프가 아닌 ISO 형식으로
         objectMapper.activateDefaultTyping(
                 LaissezFaireSubTypeValidator.instance,
-                ObjectMapper.DefaultTyping.NON_FINAL
-                //JsonTypeInfo.As.PROPERTY
+                ObjectMapper.DefaultTyping.NON_FINAL,
+                JsonTypeInfo.As.PROPERTY
         );
 
         // 기본 캐시 설정

--- a/src/main/java/com/example/wherewego/global/config/CacheConfig.java
+++ b/src/main/java/com/example/wherewego/global/config/CacheConfig.java
@@ -2,6 +2,11 @@ package com.example.wherewego.global.config;
 
 import java.time.Duration;
 
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.jsontype.impl.LaissezFaireSubTypeValidator;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import org.springframework.cache.CacheManager;
 import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.context.annotation.Bean;
@@ -10,6 +15,7 @@ import org.springframework.context.annotation.Profile;
 import org.springframework.data.redis.cache.RedisCacheConfiguration;
 import org.springframework.data.redis.cache.RedisCacheManager;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
 import org.springframework.data.redis.serializer.RedisSerializationContext;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
@@ -22,7 +28,7 @@ import org.springframework.data.redis.serializer.StringRedisSerializer;
  */
 @Configuration
 @EnableCaching
-@Profile("!local") // local 프로필에서는 캐싱 비활성화
+//@Profile("!local") // local 프로필에서는 캐싱 비활성화
 public class CacheConfig {
 
     /**
@@ -33,13 +39,23 @@ public class CacheConfig {
      */
     @Bean
     public CacheManager cacheManager(RedisConnectionFactory redisConnectionFactory) {
+        // LocalDateTime 변환을 포함한 ObjectMapper 설정
+        ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.registerModule(new JavaTimeModule()); // JavaTimeModule 등록
+        objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS); // 날짜를 타임스탬프가 아닌 ISO 형식으로
+        objectMapper.activateDefaultTyping(
+                LaissezFaireSubTypeValidator.instance,
+                ObjectMapper.DefaultTyping.NON_FINAL
+                //JsonTypeInfo.As.PROPERTY
+        );
+
         // 기본 캐시 설정
         RedisCacheConfiguration defaultConfig = RedisCacheConfiguration.defaultCacheConfig()
             .entryTtl(Duration.ofMinutes(30)) // 기본 TTL: 30분
             .serializeKeysWith(RedisSerializationContext.SerializationPair
                 .fromSerializer(new StringRedisSerializer()))
             .serializeValuesWith(RedisSerializationContext.SerializationPair
-                .fromSerializer(new GenericJackson2JsonRedisSerializer()))
+                .fromSerializer(new GenericJackson2JsonRedisSerializer(objectMapper)))
             .disableCachingNullValues(); // null 값 캐싱 비활성화
 
         return RedisCacheManager.builder(redisConnectionFactory)
@@ -53,5 +69,26 @@ public class CacheConfig {
             .withCacheConfiguration("place-stats", 
                 defaultConfig.entryTtl(Duration.ofMinutes(10))) // 장소 통계: 10분 (DB 부하 감소)
             .build();
+    }
+
+    /**
+     * RedisTemplate Bean 설정
+     *
+     * @param connectionFactory Redis 연결 팩토리
+     * @return RedisTemplate<String, Object> 인스턴스
+     */
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate(RedisConnectionFactory connectionFactory) {
+        RedisTemplate<String, Object> template = new RedisTemplate<>();
+        template.setConnectionFactory(connectionFactory);
+
+        // key, value 직렬화 방식 설정 (필요시)
+        template.setKeySerializer(new StringRedisSerializer());
+        template.setValueSerializer(new GenericJackson2JsonRedisSerializer());
+
+        template.setHashKeySerializer(new StringRedisSerializer());
+        template.setHashValueSerializer(new GenericJackson2JsonRedisSerializer());
+
+        return template;
     }
 }

--- a/src/main/java/com/example/wherewego/global/response/PagedResponse.java
+++ b/src/main/java/com/example/wherewego/global/response/PagedResponse.java
@@ -1,5 +1,8 @@
 package com.example.wherewego.global.response;
 
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 import org.springframework.data.domain.Page;
 
 import java.util.List;
@@ -10,14 +13,16 @@ import java.util.List;
  *
  * @param <T> 페이지에 담길 개별 요소 타입
  */
-public record PagedResponse<T> (
-        List<T> content,       // 현재 페이지에 포함된 데이터 리스트
-        long totalElements,     // 전체 항목 수
-        int totalPages,         // 전체 페이지 수
-        int size,               // 페이지 크기
-        int number              // 현재 페이지 번호 (0부터 시작)
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class PagedResponse<T> {
+        private List<T> content;        // 현재 페이지에 포함된 데이터 리스트
+        private long totalElements;     // 전체 항목 수
+        private int totalPages;         // 전체 페이지 수
+        private int size;               // 페이지 크기
+        private int number;             // 현재 페이지 번호 (0부터 시작)
 
-) {
     /**
      * Spring Data의 Page 객체로부터 PagedResponse 객체를 생성합니다.
      *
@@ -35,3 +40,4 @@ public record PagedResponse<T> (
         );
     }
 }
+

--- a/src/main/java/com/example/wherewego/global/util/CacheKeyUtil.java
+++ b/src/main/java/com/example/wherewego/global/util/CacheKeyUtil.java
@@ -169,4 +169,18 @@ public class CacheKeyUtil {
                 + "page" + DELIMITER + pageNumber + DELIMITER
                 + "size" + DELIMITER + size;
     }
+
+    /**
+     * 특정 사용자의 코스 북마크 목록 조회 결과에 대한 캐시 키 생성
+     *
+     * @param userId 북마크를 조회할 사용자 ID
+     * @param pageNumber 페이지 번호
+     * @param size 페이지 크기
+     * @return 캐시 키
+     */
+    public String generateCourseBookmarkListKey(String userId, String pageNumber, String size) {
+        return "userId" + DELIMITER + userId + DELIMITER
+                + "page" + DELIMITER + pageNumber + DELIMITER
+                + "size" + DELIMITER + size;
+    }
 }

--- a/src/main/java/com/example/wherewego/global/util/CacheKeyUtil.java
+++ b/src/main/java/com/example/wherewego/global/util/CacheKeyUtil.java
@@ -132,11 +132,41 @@ public class CacheKeyUtil {
      * 사용자의 코스 좋아요 목록 조회 결과에 대한 캐시 키 생성
      *
      * @param userId 사용자 ID
+     * @param page 페이지 번호
+     * @param size 페이지 크기
      * @return 캐시 키
      */
     public String generateCourseLikeListKey(String userId, String page, String size) {
-        return "userId" + DELIMITER + userId
-                + "page" + DELIMITER + page
+        return "userId" + DELIMITER + userId + DELIMITER
+                + "page" + DELIMITER + page + DELIMITER
+                + "size" + DELIMITER + size;
+    }
+
+    /**
+     * 특정 코스의 댓글 목록 조회 결과에 대한 캐시 키 생성
+     *
+     * @param courseId 댓글을 조회할 코스 ID
+     * @param pageNumber 페이지 번호
+     * @param size 페이지 크기
+     * @return 캐시 키
+     */
+    public String generateCourseCommentListKey(String courseId, String pageNumber, String size) {
+        return "courseId" + DELIMITER + courseId + DELIMITER
+                + "page" + DELIMITER + pageNumber + DELIMITER
+                + "size" + DELIMITER + size;
+    }
+
+    /**
+     * 특정 사용자의 댓글 목록 조회 결과에 대한 캐시 키 생성
+     *
+     * @param userId 댓글을 조회할 사용자 ID
+     * @param pageNumber 페이지 번호
+     * @param size 페이지 크기
+     * @return 캐시 키
+     */
+    public String generateUserCommentListKey(String userId, String pageNumber, String size) {
+        return "userId" + DELIMITER + userId + DELIMITER
+                + "page" + DELIMITER + pageNumber + DELIMITER
                 + "size" + DELIMITER + size;
     }
 }


### PR DESCRIPTION
## ✅ 작업 개요 (What)
- 코스에 대한 좋아요 캐싱 수정
- 코스에 대한 댓글, 북마크 캐싱 적용
- 특정 유저에 대한 댓글 목록 조회 캐싱 적용

## 🎯 작업 목적 (Why)


## 🛠️ 작업 내용 (How)


## ⚠️ 고려 사항
- PagedResponse : Jackson 역직렬화 시 어떤 클래스인지 찾을 수 없는 문제로 인해 record -> class타입으로 변경
- local.properties로 실행시, CacheConfig에 있는 **"@Profile("!local")"**를 주석처리 필요

## 📎 참고 자료
