### PR TITLE
refactor: 알림 읽음 처리 메서드에서 조회와 권한검증 함께 처리하도록 수정

### DIFF
--- a/src/main/java/com/example/wherewego/domain/courses/repository/NotificationRepository.java
+++ b/src/main/java/com/example/wherewego/domain/courses/repository/NotificationRepository.java
@@ -1,5 +1,7 @@
 package com.example.wherewego.domain.courses.repository;
 
+import java.util.Optional;
+
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -12,6 +14,9 @@ public interface NotificationRepository extends JpaRepository<Notification, Long
 
 	// 특정 사용자의 알림 목록을 조회 (최신순)
 	Page<Notification> findByReceiverIdOrderByCreatedAtDesc(Long receiverId, Pageable pageable);
+
+	// 알림 읽음 처리 시 조회 (권한 검증 + 데이터 조회)
+	Optional<Notification> findByIdAndReceiverId(Long id, Long receiverId);
 
 	// 읽지 않은 알림만 조회 (상단 알림뱃지 갯수)
 	long countByReceiverIdAndIsReadFalse(Long receiverId);

--- a/src/main/java/com/example/wherewego/domain/courses/service/NotificationService.java
+++ b/src/main/java/com/example/wherewego/domain/courses/service/NotificationService.java
@@ -122,13 +122,8 @@ public class NotificationService {
 	@Transactional
 	public NotificationResponseDto markAsRead(Long notificationId, Long userId) {
 		// 1. 알림 조회
-		Notification notification = notificationRepository.findById(notificationId)
+		Notification notification = notificationRepository.findByIdAndReceiverId(notificationId, userId)
 			.orElseThrow(() -> new CustomException(ErrorCode.NOTIFICATION_NOT_FOUND));
-
-		// 2. 권한 체크 (알림 수신자가 본인인지)
-		if (!notification.getReceiverId().equals(userId)) {
-			throw new CustomException(ErrorCode.UNAUTHORIZED_NOTIFICATION_ACCESS);
-		}
 
 		// 3. 이미 읽음이면 그냥 반환
 		if (!notification.isRead()) {

--- a/src/main/java/com/example/wherewego/domain/courses/service/NotificationService.java
+++ b/src/main/java/com/example/wherewego/domain/courses/service/NotificationService.java
@@ -121,16 +121,16 @@ public class NotificationService {
 	 */
 	@Transactional
 	public NotificationResponseDto markAsRead(Long notificationId, Long userId) {
-		// 1. 알림 조회
+		// 1. 알림 단건 조회 + 권한 검증 (알림 수신자 본인 맞는지)
 		Notification notification = notificationRepository.findByIdAndReceiverId(notificationId, userId)
 			.orElseThrow(() -> new CustomException(ErrorCode.NOTIFICATION_NOT_FOUND));
 
-		// 3. 이미 읽음이면 그냥 반환
+		// 2. 이미 읽음이면 그냥 반환
 		if (!notification.isRead()) {
 			notification.markAsRead(); // isRead = true
 		}
 
-		// 4. DTO 변환 및 반환
+		// 3. DTO 변환 및 반환
 		return NotificationResponseDto.of(notification);
 	}
 


### PR DESCRIPTION
## ✅ 작업 개요 (What)
알림 읽음처리 기능 리팩터

## 🎯 작업 목적 (Why)
기존: findById() → (별도) 수신자 검증 → 읽음 처리
변경: 리포지토리에서 id + receiverId로 단건 조회하여, 조회=권한검증을 한 번에 수행

## 🛠️ 작업 내용 (How)
- [ ] NotificationService 알림 단건 조회 및 권한 검증 후 읽음 처리
- [ ] NotificationRepository 알림 단건 조회 및 권한 검증 쿼리 추가
