### PR TITLE
refactor: Places API 캐싱 최적화 및 불필요한 오버로드 메서드 제거

### DIFF
--- a/src/main/java/com/example/wherewego/domain/places/dto/response/PlaceDetailResponseDto.java
+++ b/src/main/java/com/example/wherewego/domain/places/dto/response/PlaceDetailResponseDto.java
@@ -28,14 +28,12 @@ import lombok.NoArgsConstructor;
  *   },
  *   "address": "대한민국 서울특별시 강남구 학동로 419",
  *   "roadAddress": null,
- *   "phone": "1522-3232",
  *   "latitude": 37.5182675,
  *   "longitude": 127.0459628,
  *   "distance": 123,
  *   "averageRating": 4.2,     // 우리 서비스 내부 평점
  *   "reviewCount": 156,       // 우리 서비스 리뷰 수
  *   "googleRating": 4.3,      // 구글 평점 (참고용)
- *   "placeUrl": "https://maps.google.com/?cid=10405541606252947222",
  *   "bookmarkCount": 89,
  *   "isBookmarked": false,
  *   "photo": "https://maps.googleapis.com/maps/api/place/photo?maxwidth=800&photoreference=CmRaAAAA...&key=API_KEY"
@@ -76,10 +74,6 @@ public class PlaceDetailResponseDto {
 	 */
 	private String roadAddress;        // 도로명 주소
 	/**
-	 * 장소 전화번호
-	 */
-	private String phone;              // 전화번호
-	/**
 	 * 장소의 위도
 	 */
 	private Double latitude;           // 위도
@@ -103,10 +97,6 @@ public class PlaceDetailResponseDto {
 	 * Google에서 제공하는 평점 (1.0~5.0, 참고용)
 	 */
 	private Double googleRating;       // 구글 평점 (1.0~5.0, 참고용)
-	/**
-	 * Google Maps에서 장소를 볼 수 있는 URL
-	 */
-	private String placeUrl;           // 구글 맵스 URL
 	/**
 	 * 장소의 총 북마크 수
 	 */

--- a/src/main/java/com/example/wherewego/domain/places/service/GooglePlaceConverter.java
+++ b/src/main/java/com/example/wherewego/domain/places/service/GooglePlaceConverter.java
@@ -36,8 +36,6 @@ public class GooglePlaceConverter {
             .placeId(detail.getPlaceId())
             .name(detail.getName())
             .address(detail.getFormattedAddress())
-            .phone(detail.getFormattedPhoneNumber())
-            .placeUrl(detail.getUrl())
             .averageRating(0.0)  // 우리 서비스 평점 (기본값)
             .reviewCount(0)      // 우리 서비스 리뷰 수 (기본값)
             .bookmarkCount(0)    // 북마크 수 (기본값)
@@ -92,13 +90,11 @@ public class GooglePlaceConverter {
             .category(extractMainCategory(result.getTypes()))
             .address(result.getFormattedAddress())
             .roadAddress(null) // 구글은 roadAddress 구분 없음
-            .phone(null) // Text Search에는 전화번호 없음 (Details에서 가져와야 함)
             .latitude(getLatitudeFromGeometry(result))
             .longitude(getLongitudeFromGeometry(result))
             .averageRating(0.0) // 우리 서비스 평점 (추후 계산)
             .reviewCount(0) // 우리 서비스 리뷰 수 (추후 계산)
             .googleRating(result.getRating()) // 구글 평점
-            .placeUrl(null) // Text Search에는 URL 없음
             .bookmarkCount(0) // 추후 계산
             .isBookmarked(false); // 추후 계산
 

--- a/src/test/java/com/example/wherewego/domain/places/service/PlaceServiceTest.java
+++ b/src/test/java/com/example/wherewego/domain/places/service/PlaceServiceTest.java
@@ -86,7 +86,7 @@ class PlaceServiceTest {
 				.willReturn(Arrays.<Object[]>asList(new Object[]{placeId, 5L}));
 
 			// when
-			PlaceStatsDto result = placeService.getPlaceStats(placeId);
+			PlaceStatsDto result = placeService.getPlaceStats(placeId, null);
 
 			// then
 			assertThat(result).isNotNull();
@@ -110,7 +110,7 @@ class PlaceServiceTest {
 				.willReturn(Arrays.<Object[]>asList(new Object[]{placeId, 0L}));
 
 			// when
-			PlaceStatsDto result = placeService.getPlaceStats(placeId);
+			PlaceStatsDto result = placeService.getPlaceStats(placeId, null);
 
 			// then
 			assertThat(result.getAverageRating()).isEqualTo(0.0);
@@ -128,7 +128,7 @@ class PlaceServiceTest {
 				.willReturn(Arrays.<Object[]>asList(new Object[]{placeId, 0L}));
 
 			// when
-			PlaceStatsDto result = placeService.getPlaceStats(placeId);
+			PlaceStatsDto result = placeService.getPlaceStats(placeId, null);
 
 			// then
 			assertThat(result.getAverageRating()).isEqualTo(4.67);
@@ -221,7 +221,7 @@ class PlaceServiceTest {
 				));
 
 			// when
-			Map<String, PlaceStatsDto> result = placeService.getPlaceStatsMap(placeIds);
+			Map<String, PlaceStatsDto> result = placeService.getPlaceStatsMap(placeIds, null);
 
 			// then
 			assertThat(result).hasSize(3);


### PR DESCRIPTION


## ✅ 작업 개요 (What)
refactor: Places API 캐싱 최적화 및 불필요한 오버로드 메서드 제거

## 🎯 작업 목적 (Why)
refactor: Places API 캐싱 최적화 및 불필요한 오버로드 메서드 제거

## 🛠️ 작업 내용 (How)
- Search 결과를 Detail 캐시에 직접 저장하여 API 호출 최적화
- Text Search에서 제공하지 않는 phone, placeUrl 필드 제거
- 게스트용 오버로드 메서드 제거로 코드 간소화

## ⚠️ 고려 사항

## 📎 참고 자료