### PR TITLE
Feat/notification: 읽은 알림 전체 삭제 기능 구현

### DIFF
--- a/src/main/java/com/example/wherewego/domain/courses/repository/NotificationRepository.java
+++ b/src/main/java/com/example/wherewego/domain/courses/repository/NotificationRepository.java
@@ -5,6 +5,9 @@ import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import com.example.wherewego.domain.courses.entity.Notification;
@@ -20,4 +23,13 @@ public interface NotificationRepository extends JpaRepository<Notification, Long
 
 	// 읽지 않은 알림만 조회 (상단 알림뱃지 갯수)
 	long countByReceiverIdAndIsReadFalse(Long receiverId);
+
+	// 읽은 알림 전체 삭제
+	@Modifying(clearAutomatically = true, flushAutomatically = true)
+	@Query("""
+		    DELETE FROM Notification n
+		    WHERE n.receiverId = :userId
+		      AND n.isRead = true
+		""")
+	int deleteByReceiverIdAndIsReadTrue(@Param("userId") Long userId);
 }

--- a/src/main/java/com/example/wherewego/domain/courses/service/NotificationService.java
+++ b/src/main/java/com/example/wherewego/domain/courses/service/NotificationService.java
@@ -148,4 +148,12 @@ public class NotificationService {
 		return NotificationResponseDto.of(notification);
 	}
 
+	/**
+	 * 현재 사용자 기준 읽은 알림 전체 하드 딜리트
+	 */
+	@Transactional
+	public void deleteAllRead(Long userId) {
+		notificationRepository.deleteByReceiverIdAndIsReadTrue(userId);
+	}
+
 }

--- a/src/main/java/com/example/wherewego/domain/user/controller/UserController.java
+++ b/src/main/java/com/example/wherewego/domain/user/controller/UserController.java
@@ -19,6 +19,7 @@ import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.example.wherewego.domain.auth.security.CustomUserDetail;
+import com.example.wherewego.domain.common.enums.OrderStatus;
 import com.example.wherewego.domain.courses.dto.response.CommentResponseDto;
 import com.example.wherewego.domain.courses.dto.response.CourseLikeListResponseDto;
 import com.example.wherewego.domain.courses.dto.response.CourseListResponseDto;
@@ -29,7 +30,6 @@ import com.example.wherewego.domain.courses.service.CourseBookmarkService;
 import com.example.wherewego.domain.courses.service.CourseLikeService;
 import com.example.wherewego.domain.courses.service.CourseService;
 import com.example.wherewego.domain.courses.service.NotificationService;
-import com.example.wherewego.domain.common.enums.OrderStatus;
 import com.example.wherewego.domain.order.dto.response.MyOrderResponseDto;
 import com.example.wherewego.domain.order.service.OrderService;
 import com.example.wherewego.domain.places.dto.response.PlaceReviewResponseDto;
@@ -358,6 +358,21 @@ public class UserController {
 		Long userId = userDetail.getUser().getId();
 		NotificationResponseDto response = notificationService.markAsRead(notificationId, userId);
 		return ApiResponse.ok("알림이 읽음 처리되었습니다.", response);
+	}
+
+	/**
+	 * 읽은 알림 전체 삭제 API
+	 * DELETE /api/users/mypage/notifications/read
+	 */
+	@DeleteMapping("/mypage/notifications/read")
+	@ResponseStatus(HttpStatus.NO_CONTENT)
+	public ApiResponse<Void> deleteReadNotifications(
+		@AuthenticationPrincipal CustomUserDetail userDetail) {
+
+		Long userId = userDetail.getUser().getId();
+		notificationService.deleteAllRead(userId);
+
+		return ApiResponse.noContent("읽은 알림이 전체 삭제 되었습니다.");
 	}
 
 }

--- a/src/test/java/com/example/wherewego/domain/course/service/NotificationServiceTest.java
+++ b/src/test/java/com/example/wherewego/domain/course/service/NotificationServiceTest.java
@@ -1,4 +1,4 @@
-package com.example.wherewego.domain.courses.service;
+package com.example.wherewego.domain.course.service;
 
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.Mockito.*;
@@ -22,6 +22,7 @@ import com.example.wherewego.domain.courses.dto.request.NotificationRequestDto;
 import com.example.wherewego.domain.courses.dto.response.NotificationResponseDto;
 import com.example.wherewego.domain.courses.entity.Notification;
 import com.example.wherewego.domain.courses.repository.NotificationRepository;
+import com.example.wherewego.domain.courses.service.NotificationService;
 
 class NotificationServiceTest {
 
@@ -105,7 +106,8 @@ class NotificationServiceTest {
 			.message("msg")
 			.build();
 
-		when(notificationRepository.findById(notiId)).thenReturn(Optional.of(notification));
+		when(notificationRepository.findByIdAndReceiverId(notiId, userId))
+			.thenReturn(Optional.of(notification));
 
 		// when
 		NotificationResponseDto result = notificationService.markAsRead(notiId, userId);


### PR DESCRIPTION
## ✅ 작업 개요 (What)
알림 기능 중 읽은 알림 삭제 기능
-사용자가 읽은 알림을 일괄 삭제할 수 있음

## 🛠️ 작업 내용 (How)
- [ ] NotificationService 읽은 알림 삭제 메서드
- [ ] NotificationRepository 읽은 알림 삭제 쿼리
- [ ] UserController

## ⚠️ 고려 사항
-마이페이지 기능에 있는 내 알림 목록 조회에서 삭제하기 버튼이 있다고 가정했습니다
-지금은 삭제 전에 특별히 할 일이 없어서 레포지토리에서 바로 삭제하는걸로 구현했습니다. 레포지토리에서 조회하고 서비스에서 지우는 방식으로 구현한다고 한다면, 데이터를 전부 메모리로 불러왔다가 다시 지워야 해서 비효율적이라고 판단했습니다. DELETE 쿼리 처음써봐서 자세히 리뷰해주시면 감사하겠습니다
