### PR TITLE
refactor: deleteAllRead를 boolean 파라미터 방식으로 변경

### DIFF
--- a/src/main/java/com/example/wherewego/domain/courses/repository/NotificationRepository.java
+++ b/src/main/java/com/example/wherewego/domain/courses/repository/NotificationRepository.java
@@ -6,8 +6,6 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import com.example.wherewego.domain.courses.entity.Notification;
@@ -26,10 +24,5 @@ public interface NotificationRepository extends JpaRepository<Notification, Long
 
 	// 읽은 알림 전체 삭제
 	@Modifying(clearAutomatically = true, flushAutomatically = true)
-	@Query("""
-		    DELETE FROM Notification n
-		    WHERE n.receiverId = :userId
-		      AND n.isRead = true
-		""")
-	int deleteByReceiverIdAndIsReadTrue(@Param("userId") Long userId);
+	void deleteByReceiverIdAndIsRead(Long receiverId, boolean isRead);
 }

--- a/src/main/java/com/example/wherewego/domain/courses/service/NotificationService.java
+++ b/src/main/java/com/example/wherewego/domain/courses/service/NotificationService.java
@@ -153,7 +153,7 @@ public class NotificationService {
 	 */
 	@Transactional
 	public void deleteAllRead(Long userId) {
-		notificationRepository.deleteByReceiverIdAndIsReadTrue(userId);
+		notificationRepository.deleteByReceiverIdAndIsRead(userId, true);
 	}
 
 }


### PR DESCRIPTION
## ✅ 작업 개요 (What)
알림 기능 중 튜터님 피드백 내용 적용
읽은 알림 전체 삭제 메서드 deleteAllRead에서 boolean 파라미터 받는 것으로 변경

## 🛠️ 작업 내용 (How)
- [ ] NotificationService의 deleteAllRead
- [ ] NotificationRepository의 deleteByReceiverIdAndIsRead

## ⚠️ 고려 사항
알림 읽음 처리에서 권한 검증하는 부분이 중복인지도 확인했는데 중복은 없어서 그대로 뒀습니다 
